### PR TITLE
Generate ids for Sandworm issues

### DIFF
--- a/src/issues/meta.js
+++ b/src/issues/meta.js
@@ -1,4 +1,4 @@
-const {getFindings} = require('./utils');
+const {getFindings, getUniqueIssueId} = require('./utils');
 
 const INSTALL_SCRIPT_NAME = ['preinstall', 'install', 'postinstall'];
 
@@ -13,6 +13,7 @@ module.exports = {
           title: 'Deprecated package',
           name: dep.name,
           version: dep.version,
+          sandwormIssueCode: 200,
         });
       }
 
@@ -32,6 +33,8 @@ module.exports = {
             shortTitle: `Uses ${scriptName} script`,
             name: dep.name,
             version: dep.version,
+            sandwormIssueCode: 201,
+            sandwormIssueSpecifier: scriptName,
           });
         }
       });
@@ -43,6 +46,7 @@ module.exports = {
           shortTitle: 'Has no repository',
           name: dep.name,
           version: dep.version,
+          sandwormIssueCode: 202,
         });
       }
 
@@ -54,6 +58,8 @@ module.exports = {
             shortTitle: 'Has HTTP dependency',
             name: dep.name,
             version: dep.version,
+            sandwormIssueCode: 203,
+            sandwormIssueSpecifier: depname,
           });
         } else if (depstring.startsWith('git')) {
           issues.push({
@@ -62,6 +68,8 @@ module.exports = {
             shortTitle: 'Has GIT dependency',
             name: dep.name,
             version: dep.version,
+            sandwormIssueCode: 204,
+            sandwormIssueSpecifier: depname,
           });
         } else if (depstring.startsWith('file')) {
           issues.push({
@@ -70,6 +78,8 @@ module.exports = {
             shortTitle: 'Has file dependency',
             name: dep.name,
             version: dep.version,
+            sandwormIssueCode: 205,
+            sandwormIssueSpecifier: depname,
           });
         }
       });
@@ -77,6 +87,12 @@ module.exports = {
 
     return issues.map((issue) => ({
       ...issue,
+      sandwormIssueId: getUniqueIssueId({
+        code: issue.sandwormIssueCode,
+        name: issue.name,
+        version: issue.version,
+        specifier: issue.sandwormIssueSpecifier,
+      }),
       findings: getFindings({
         packageGraph,
         packageName: issue.name,

--- a/src/issues/utils.js
+++ b/src/issues/utils.js
@@ -130,4 +130,7 @@ const getReports = (packageName, packageVersion, packageGraph) =>
     req.end();
   });
 
-module.exports = {getReports, getFindings, reportFromAdvisory};
+const getUniqueIssueId = ({code, name, version, specifier}) =>
+  `SWRM-${code}-${name}-${version}${specifier ? `-${specifier}` : ''}`;
+
+module.exports = {getReports, getFindings, reportFromAdvisory, getUniqueIssueId};


### PR DESCRIPTION
This PR adds generating unique ids to all issues that Sandworm detects.
- ids are assigned to `license` and `meta` issues
- ids are NOT assigned to vulnerabilities, as they have their own ids already
- ids are saved on the `sandwormIssueId` property of an issue
- all issues have also been assigned a code `sandwormIssueCode` and an optional specifier `sandwormIssueSpecifier`
- `license` issues have been assigned 1XX codes
- `meta` issues have been assigned 2xx codes

For most issues, the id is a combination of issue code + package name + package version:

`SWRM-102-spdx-license-ids-3.0.12`

Some issues might be generated more than once for a single version, so they also append a specifier:

- `SWRM-201` install scripts issue is created once for each install script used (pre/post), and will generate ids like `SWRM-201-core-js-3.29.0-postinstall`
- `SWRM-203`, `SWRM-204`, and `SWRM-205` are created once for each http/git/file dependency in a manifest, and will generate ids like `SWRM-203-core-js-3.29.0-react`

I've explored hashing the ids, but I think the explicit form is easier to read and use.

Fixes #54 