### PR TITLE
Notification on new version available

### DIFF
--- a/src/cli/checkUpdates.js
+++ b/src/cli/checkUpdates.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const semver = require('semver');
+const {loadManifest} = require('../files');
+const {getRegistryData} = require('../graph/utils');
+const logger = require('./logger');
+
+module.exports = async () => {
+  const {version: currentVersion} = await loadManifest(path.join(__dirname, '../..'));
+  const data = await getRegistryData('@sandworm/audit');
+  const latestVersion = data['dist-tags']?.latest;
+
+  if (semver.lt(currentVersion, latestVersion)) {
+    logger.log(
+      `🔔 ${logger.colors.BG_CYAN}${logger.colors.BLACK}%s${logger.colors.RESET}\n`,
+      'New version available! Run "npm i -g @sandworm/audit" to update.',
+    );
+  }
+};

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -10,6 +10,7 @@ const {getIssueCounts, failIfRequested} = require('./utils');
 const command = require('./command');
 const summary = require('./summary');
 const logger = require('./logger');
+const checkUpdates = require('./checkUpdates');
 
 command(async (argv) => {
   logger.logColor(logger.colors.CYAN, 'Sandworm 🪱');
@@ -132,4 +133,12 @@ command(async (argv) => {
   if (failOn) {
     failIfRequested({failOn, issueCountsByType});
   }
+
+  // *****************
+  // Check for updates
+  // *****************
+  try {
+    await checkUpdates();
+    // eslint-disable-next-line no-empty
+  } catch (error) {}
 });

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -1,7 +1,9 @@
 const logger = console;
 const colors = {
   RESET: '\x1b[0m',
+  BLACK: '\x1b[30m',
   CYAN: '\x1b[36m',
+  BG_CYAN: '\x1b[46m',
   RED: '\x1b[31m',
   DIM: '\x1b[2m',
   CRIMSON: '\x1b[38m',

--- a/src/graph/utils.js
+++ b/src/graph/utils.js
@@ -276,12 +276,13 @@ const getRegistryData = (packageName, packageVersion) =>
         res.on('end', () => {
           try {
             const response = JSON.parse(Buffer.concat(data).toString());
+            const requestedVersion = packageVersion || response['dist-tags']?.latest;
 
             resolve({
               ...response,
-              ...(response.versions?.[packageVersion] || {}),
-              published: response.time?.[packageVersion],
-              size: response.versions?.[packageVersion]?.dist?.unpackedSize,
+              ...(response.versions?.[requestedVersion] || {}),
+              published: response.time?.[requestedVersion],
+              size: response.versions?.[requestedVersion]?.dist?.unpackedSize,
               versions: undefined,
               time: undefined,
             });


### PR DESCRIPTION
This PR adds a console notification to let users know when a new version is available.

<img width="487" alt="image" src="https://user-images.githubusercontent.com/5381731/223575031-f2ea2bcf-5f7d-4a0d-b39a-5a1481326e4b.png">

ℹ️ `getRegistryData` now accepts a package name without a version, and it will default to the latest version (if defined in the response from the registry).

Closes #56 