### PR TITLE
`-v` displays the current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Available options:
 
 ```
 Options:
-      --version               Show version number                      [boolean]
+  -v, --version               Show version number                      [boolean]
       --help                  Show help                                [boolean]
   -o, --output-path           The path of the output directory, relative to the
                               application path    [string] [default: "sandworm"]
   -d, --include-dev           Include dev dependencies[boolean] [default: false]
-  -v, --show-versions         Show package versions in chart names
+      --sv, --show-versions   Show package versions in chart names
                                                       [boolean] [default: false]
   -p, --path                  The path to the application to audit      [string]
       --md, --max-depth       Max depth to represent in charts          [number]
@@ -97,6 +97,9 @@ Options:
       --lp, --license-policy  Custom license policy JSON string         [string]
   -f, --from                  Load data from "registry" or "disk"
                                                   [string] [default: "registry"]
+      --fo, --fail-on         Fail policy JSON string   [string] [default: "[]"]
+  -s, --summary               Print a summary of the audit results to the
+                              console                  [boolean] [default: true]
 ```
 
 ### Documentation

--- a/src/cli/cmds/audit.js
+++ b/src/cli/cmds/audit.js
@@ -29,7 +29,7 @@ exports.builder = (yargs) =>
       describe: 'Include dev dependencies',
       type: 'boolean',
     })
-    .option('v', {
+    .option('sv', {
       alias: 'show-versions',
       demandOption: false,
       default: false,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,4 +2,10 @@
 const Yargs = require('yargs');
 
 // eslint-disable-next-line no-unused-expressions
-Yargs(process.argv.slice(2)).scriptName('Sandworm').commandDir('cmds').demandCommand().help().argv;
+Yargs(process.argv.slice(2))
+  .scriptName('Sandworm')
+  .commandDir('cmds')
+  .demandCommand()
+  .help()
+  .alias('v', 'version')
+  .describe('v', 'Show version number').argv;


### PR DESCRIPTION
Currently, `-v` is defined as an option to the default `audit` command.
This PR makes that an alias for `--version`, which displays the current Sandworm version.

Closes #68 