### PR TITLE
fix: change default maxDepth

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const getReport = async ({
   getAdvisoriesForRoot = true,
   minDisplayedSeverity = 'high',
   width = 1500,
-  maxDepth = 7,
+  maxDepth = 5,
   licensePolicy,
   loadDataFrom = 'registry',
   onProgress = () => {},


### PR DESCRIPTION
According to https://github.com/sandworm-hq/sandworm-audit/issues/53 

After my experiments, I've come to the conclusion that the problem is the d3 graphing. I think the default depth of 7 was way too much. After changing from 7 to 5, the RAM consumption decreased from 13 to 2 gb.
If one of the options in the cli is to set the depth, then in my opinion the basic setting should satisfy almost all repos, and if someone needs more depth, or their package.json is huge, they can always edit it.