### PR TITLE
Opt-in crash reports

### DIFF
--- a/src/cli/checkUpdates.js
+++ b/src/cli/checkUpdates.js
@@ -4,9 +4,13 @@ const {loadManifest} = require('../files');
 const {getRegistryData} = require('../graph/utils');
 
 module.exports = async () => {
-  const {version: currentVersion} = await loadManifest(path.join(__dirname, '../..'));
-  const data = await getRegistryData('@sandworm/audit');
-  const latestVersion = data['dist-tags']?.latest;
+  try {
+    const {version: currentVersion} = await loadManifest(path.join(__dirname, '../..'));
+    const data = await getRegistryData('@sandworm/audit');
+    const latestVersion = data['dist-tags']?.latest;
 
-  return semver.lt(currentVersion, latestVersion);
+    return semver.lt(currentVersion, latestVersion);
+  } catch (error) {
+    return false;
+  }
 };

--- a/src/cli/cmds/audit.js
+++ b/src/cli/cmds/audit.js
@@ -9,7 +9,8 @@ const {getIssueCounts, failIfRequested} = require('../utils');
 const summary = require('../summary');
 const logger = require('../logger');
 const checkUpdates = require('../checkUpdates');
-const {outputFilenames} = require('../../files');
+const {outputFilenames, loadManifest} = require('../../files');
+const handleCrash = require('../handleCrash');
 
 exports.command = ['audit', '*'];
 exports.desc = "Security & License Compliance For Your App's Dependencies 🪱";
@@ -91,158 +92,171 @@ exports.builder = (yargs) =>
     });
 
 exports.handler = async (argv) => {
-  let isOutdated = false;
-
-  (async () => {
-    isOutdated = await checkUpdates();
-  })();
-
-  logger.logCliHeader();
-  const {default: ora} = await import('ora');
   const appPath = argv.p || process.cwd();
-  const fileConfig = loadConfig(appPath)?.audit || {};
 
-  // *****************
-  // Perform the audit
-  // *****************
-  const {
-    dependencyGraph,
-    svgs,
-    csv,
-    dependencyVulnerabilities,
-    rootVulnerabilities,
-    licenseUsage,
-    licenseIssues,
-    metaIssues,
-    resolvedIssues,
-    resolvedIssuesAlerts,
-    resolvedIssuesCount,
-    name,
-    version,
-    errors,
-  } = await getReport({
-    appPath,
-    includeDev: fileConfig.includeDev || argv.d,
-    showVersions: fileConfig.showVersions || argv.v,
-    rootIsShell: fileConfig.rootIsShell || argv.rs,
-    maxDepth: fileConfig.maxDepth || argv.md,
-    licensePolicy: fileConfig.licensePolicy || (argv.lp && JSON.parse(argv.lp)),
-    minDisplayedSeverity: fileConfig.minDisplayedSeverity,
-    loadDataFrom: fileConfig.loadDataFrom || argv.f,
-    onProgress: onProgress(ora),
-  });
+  try {
+    let isOutdated = false;
 
-  // ********************
-  // Write output to disk
-  // ********************
-  const outputSpinner = ora('Writing Output Files').start();
-  const filenames = outputFilenames(name, version);
-  const outputPath = path.join(appPath, fileConfig.outputPath || argv.o);
-  await fs.mkdir(outputPath, {recursive: true});
+    (async () => {
+      isOutdated = await checkUpdates();
+    })();
 
-  // Write charts
-  await Object.keys(svgs).reduce(async (agg, chartType) => {
-    await agg;
+    logger.logCliHeader();
+    const {default: ora} = await import('ora');
+    const fileConfig = loadConfig(appPath)?.audit || {};
 
-    const chartPath = path.join(outputPath, filenames[chartType]);
-    await fs.writeFile(chartPath, svgs[chartType]);
-  }, Promise.resolve());
+    // throw new Error('Salutare :)');
 
-  // Write CSV
-  const csvOutputPath = path.join(outputPath, filenames.dependenciesCsv);
-  await fs.writeFile(csvOutputPath, csv);
-
-  // Write JSON report
-  const report = {
-    createdAt: Date.now(),
-    packageManager: dependencyGraph.root.meta?.packageManager,
-    name,
-    version,
-    rootVulnerabilities,
-    dependencyVulnerabilities,
-    licenseUsage,
-    licenseIssues,
-    metaIssues,
-    resolvedIssues,
-    errors,
-  };
-  const reportOutputPath = path.join(outputPath, filenames.json);
-  await fs.writeFile(reportOutputPath, JSON.stringify(report, null, 2));
-
-  outputSpinner.succeed('Report written to disk');
-
-  // ***************
-  // Display results
-  // ***************
-  const issuesByType = {
-    root: rootVulnerabilities,
-    dependencies: dependencyVulnerabilities,
-    licenses: licenseIssues,
-    meta: metaIssues,
-  };
-  const {issueCountsByType, issueCountsBySeverity, totalIssueCount} = getIssueCounts(issuesByType);
-
-  logger.log('');
-  if (resolvedIssuesCount > 0) {
-    logger.logColor(
-      logger.colors.GREEN,
-      `🙌 ${resolvedIssuesCount} ${
-        resolvedIssuesCount === 1 ? 'issue' : 'issues'
-      } already resolved`,
-    );
-  }
-  if (totalIssueCount > 0) {
-    const displayableIssueCount = Object.entries(issueCountsBySeverity).filter(
-      ([, count]) => count > 0,
-    );
-
-    logger.logColor(
-      logger.colors.CYAN,
-      `⚠️ Identified ${displayableIssueCount
-        .map(([severity, count]) => `${count} ${severity} severity`)
-        .join(', ')} issues`,
-    );
-
-    if (argv.s) {
-      summary(issuesByType);
-    }
-  } else {
-    logger.logColor(logger.colors.CYAN, '✅ Zero issues identified');
-  }
-
-  if (resolvedIssuesAlerts?.length) {
-    logger.log('');
-    resolvedIssuesAlerts.forEach((alert) => {
-      logger.log(`⚠️ ${alert}`);
+    // *****************
+    // Perform the audit
+    // *****************
+    const {
+      dependencyGraph,
+      svgs,
+      csv,
+      dependencyVulnerabilities,
+      rootVulnerabilities,
+      licenseUsage,
+      licenseIssues,
+      metaIssues,
+      resolvedIssues,
+      resolvedIssuesAlerts,
+      resolvedIssuesCount,
+      name,
+      version,
+      errors,
+    } = await getReport({
+      appPath,
+      includeDev: fileConfig.includeDev || argv.d,
+      showVersions: fileConfig.showVersions || argv.v,
+      rootIsShell: fileConfig.rootIsShell || argv.rs,
+      maxDepth: fileConfig.maxDepth || argv.md,
+      licensePolicy: fileConfig.licensePolicy || (argv.lp && JSON.parse(argv.lp)),
+      minDisplayedSeverity: fileConfig.minDisplayedSeverity,
+      loadDataFrom: fileConfig.loadDataFrom || argv.f,
+      onProgress: onProgress(ora),
     });
-  }
 
-  logger.log('');
-  if (errors.length === 0) {
-    logger.log('✨ Done');
-  } else {
-    logger.log('✨ Done, but with errors:');
-    errors.forEach((error) => logger.logColor(logger.colors.RED, `❌ ${error}`));
-    logger.logColor(logger.colors.RED, '❌ Failing because of errors');
-    process.exit(1);
-  }
+    // ********************
+    // Write output to disk
+    // ********************
+    const outputSpinner = ora('Writing Output Files').start();
+    const filenames = outputFilenames(name, version);
+    const outputPath = path.join(appPath, fileConfig.outputPath || argv.o);
+    await fs.mkdir(outputPath, {recursive: true});
 
-  // *****************
-  // Fail if requested
-  // *****************
-  const failOn = fileConfig.failOn || (argv.fo && JSON.parse(argv.fo));
+    // Write charts
+    await Object.keys(svgs).reduce(async (agg, chartType) => {
+      await agg;
 
-  if (failOn) {
-    failIfRequested({failOn, issueCountsByType});
-  }
+      const chartPath = path.join(outputPath, filenames[chartType]);
+      await fs.writeFile(chartPath, svgs[chartType]);
+    }, Promise.resolve());
 
-  // *********************
-  // Outdated notification
-  // *********************
-  if (isOutdated) {
-    logger.log(
-      `🔔 ${logger.colors.BG_CYAN}${logger.colors.BLACK}%s${logger.colors.RESET}\n`,
-      'New version available! Run "npm i -g @sandworm/audit" to update.',
-    );
+    // Write CSV
+    const csvOutputPath = path.join(outputPath, filenames.dependenciesCsv);
+    await fs.writeFile(csvOutputPath, csv);
+
+    // Write JSON report
+    const {version: sandwormVersion} = await loadManifest(path.join(__dirname, '../../..'));
+    const report = {
+      createdAt: Date.now(),
+      system: {
+        sandwormVersion,
+        nodeVersion: process.versions.node,
+        ...(dependencyGraph.root.meta || {}),
+      },
+      name,
+      version,
+      rootVulnerabilities,
+      dependencyVulnerabilities,
+      licenseUsage,
+      licenseIssues,
+      metaIssues,
+      resolvedIssues,
+      errors,
+    };
+    const reportOutputPath = path.join(outputPath, filenames.json);
+    await fs.writeFile(reportOutputPath, JSON.stringify(report, null, 2));
+
+    outputSpinner.succeed('Report written to disk');
+
+    // ***************
+    // Display results
+    // ***************
+    const issuesByType = {
+      root: rootVulnerabilities,
+      dependencies: dependencyVulnerabilities,
+      licenses: licenseIssues,
+      meta: metaIssues,
+    };
+    const {issueCountsByType, issueCountsBySeverity, totalIssueCount} =
+      getIssueCounts(issuesByType);
+
+    logger.log('');
+    if (resolvedIssuesCount > 0) {
+      logger.logColor(
+        logger.colors.GREEN,
+        `🙌 ${resolvedIssuesCount} ${
+          resolvedIssuesCount === 1 ? 'issue' : 'issues'
+        } already resolved`,
+      );
+    }
+    if (totalIssueCount > 0) {
+      const displayableIssueCount = Object.entries(issueCountsBySeverity).filter(
+        ([, count]) => count > 0,
+      );
+
+      logger.logColor(
+        logger.colors.CYAN,
+        `⚠️ Identified ${displayableIssueCount
+          .map(([severity, count]) => `${count} ${severity} severity`)
+          .join(', ')} issues`,
+      );
+
+      if (argv.s) {
+        summary(issuesByType);
+      }
+    } else {
+      logger.logColor(logger.colors.CYAN, '✅ Zero issues identified');
+    }
+
+    if (resolvedIssuesAlerts?.length) {
+      logger.log('');
+      resolvedIssuesAlerts.forEach((alert) => {
+        logger.log(`⚠️ ${alert}`);
+      });
+    }
+
+    logger.log('');
+    if (errors.length === 0) {
+      logger.log('✨ Done');
+    } else {
+      logger.log('✨ Done, but with errors:');
+      errors.forEach((error) => logger.logColor(logger.colors.RED, `❌ ${error}`));
+      logger.logColor(logger.colors.RED, '❌ Failing because of errors');
+      process.exit(1);
+    }
+
+    // *****************
+    // Fail if requested
+    // *****************
+    const failOn = fileConfig.failOn || (argv.fo && JSON.parse(argv.fo));
+
+    if (failOn) {
+      failIfRequested({failOn, issueCountsByType});
+    }
+
+    // *********************
+    // Outdated notification
+    // *********************
+    if (isOutdated) {
+      logger.log(
+        `🔔 ${logger.colors.BG_CYAN}${logger.colors.BLACK}%s${logger.colors.RESET}\n`,
+        'New version available! Run "npm i -g @sandworm/audit" to update.',
+      );
+    }
+  } catch (error) {
+    await handleCrash(error, appPath);
   }
 };

--- a/src/cli/handleCrash.js
+++ b/src/cli/handleCrash.js
@@ -1,0 +1,125 @@
+const https = require('https');
+const path = require('path');
+const prompts = require('prompts');
+const {UsageError} = require('../errors');
+const {loadManifest, loadLockfile} = require('../files');
+const logger = require('./logger');
+
+const PUBLIC_ROLLBAR_ACCESS_TOKEN = '7f41bd88e3164d598d6c69a1a88ce6f2';
+
+const trackError = async (error, customData) =>
+  new Promise((resolve) => {
+    const req = https.request(
+      {
+        method: 'POST',
+        hostname: 'api.rollbar.com',
+        path: '/api/1/item/',
+        headers: {
+          'X-Rollbar-Access-Token': PUBLIC_ROLLBAR_ACCESS_TOKEN,
+          'Content-Type': 'application/json',
+        },
+        maxRedirects: 20,
+      },
+      (res) => {
+        const chunks = [];
+
+        res.on('data', (chunk) => {
+          chunks.push(chunk);
+        });
+
+        res.on('end', () => {
+          // console.log(Buffer.concat(chunks).toString());
+          resolve();
+        });
+
+        res.on('error', (err) => {
+          logger.error(err);
+          resolve();
+        });
+      },
+    );
+
+    const options = JSON.stringify({
+      data: {
+        environment: 'production',
+        body: {
+          message: {
+            body: error.stack || `${error.name} ${error.message}`,
+          },
+        },
+        platform: 'client',
+        level: 'error',
+        custom: customData,
+      },
+    });
+    req.write(options);
+
+    req.end();
+  });
+
+module.exports = async (error, appPath) => {
+  logger.log(`\n❌ Failed: ${error.message}`);
+  if (!(error instanceof UsageError)) {
+    logger.log(error.stack);
+
+    if (process.stdin.isTTY) {
+      let cancelled = false;
+      logger.log('');
+      const prompt = await prompts(
+        {
+          name: 'send',
+          type: 'select',
+          message: 'Send crash report to Sandworm?',
+          choices: [
+            {title: 'Send with dependency info', value: 'deps'},
+            {title: 'Send without dependency info', value: 'no-deps'},
+            {title: "Don't send", value: 'no'},
+          ],
+        },
+        {
+          onCancel: () => {
+            cancelled = true;
+          },
+        },
+      );
+
+      if (!cancelled && prompt.send !== 'no') {
+        const {version} = await loadManifest(path.join(__dirname, '../..'));
+        const data = {
+          sandwormVersion: version,
+          nodeVersion: process.versions.node,
+        };
+
+        try {
+          const lockfileData = await loadLockfile(appPath);
+
+          Object.assign(data, {
+            manager: lockfileData.manager,
+            managerVersion: lockfileData.managerVersion,
+            lockfileVersion: lockfileData.lockfileVersion,
+          });
+          // eslint-disable-next-line no-empty
+        } catch {}
+
+        if (prompt.send === 'deps') {
+          try {
+            const {dependencies, devDependencies, optionalDependencies, peerDependencies} =
+              await loadManifest(appPath);
+
+            Object.assign(data, {
+              dependencies: JSON.stringify(dependencies),
+              devDependencies: JSON.stringify(devDependencies),
+              optionalDependencies: JSON.stringify(optionalDependencies),
+              peerDependencies: JSON.stringify(peerDependencies),
+            });
+            // eslint-disable-next-line no-empty
+          } catch {}
+        }
+
+        await trackError(error, data);
+      }
+    }
+  }
+
+  process.exit(1);
+};

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,10 @@
+class UsageError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'UsageError';
+  }
+}
+
+module.exports = {
+  UsageError,
+};

--- a/src/issues/utils.js
+++ b/src/issues/utils.js
@@ -1,6 +1,7 @@
 const https = require('https');
 const semverSatisfies = require('semver/functions/satisfies');
 const {aggregateDependencies} = require('../charts/utils');
+const {UsageError} = require('../errors');
 
 const getPathsForPackage = (packageGraph, packageName, semver) => {
   const parse = (node, currentPath = [], depth = 0, seenNodes = []) => {
@@ -173,16 +174,16 @@ const excludeResolved = (issues = [], resolved = []) => {
 
 const validateResolvedIssues = (resolvedIssues = [], currentIssues = []) => {
   if (!Array.isArray(resolvedIssues)) {
-    throw new Error('Resolved issues must be array');
+    throw new UsageError('Resolved issues must be array');
   }
   return resolvedIssues.reduce((agg, resolvedIssue) => {
     if (!resolvedIssue.id || !resolvedIssue.paths || !resolvedIssue.notes) {
-      throw new Error(
+      throw new UsageError(
         'Each resolved issue must have the following fields: "id", "paths", and "notes"',
       );
     }
     if (!Array.isArray(resolvedIssue.paths)) {
-      throw new Error('Issue paths must be array');
+      throw new UsageError('Issue paths must be array');
     }
 
     const currentIssue = currentIssues.find(

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,3 +1,5 @@
+const {UsageError} = require('./errors');
+
 const SUPPORTED_SEVERITIES = ['critical', 'high', 'moderate', 'low'];
 
 module.exports = ({
@@ -11,38 +13,51 @@ module.exports = ({
   onProgress,
 }) => {
   if (!appPath) {
-    throw new Error(
+    throw new UsageError(
       'Application path is required - please provide the path to a directory containing your manifest and a lockfile.',
     );
   }
-  if (dependencyGraph && (!dependencyGraph.root || !dependencyGraph.all || !dependencyGraph.prodDependencies)) {
-    throw new Error('Provided dependency graph is invalid - missing one or more required fields.');
+  if (
+    dependencyGraph &&
+    (!dependencyGraph.root || !dependencyGraph.all || !dependencyGraph.prodDependencies)
+  ) {
+    throw new UsageError(
+      'Provided dependency graph is invalid - missing one or more required fields.',
+    );
   }
   if (!SUPPORTED_SEVERITIES.includes(minDisplayedSeverity)) {
-    throw new Error(`\`minDisplayedSeverity\` must be one of ${SUPPORTED_SEVERITIES.map(s => `\`${s}\``).join(', ')}.`);
+    throw new UsageError(
+      `\`minDisplayedSeverity\` must be one of ${SUPPORTED_SEVERITIES.map((s) => `\`${s}\``).join(
+        ', ',
+      )}.`,
+    );
   }
   if (!Number.isInteger(width)) {
-    throw new Error('Width must be a valid integer.');
+    throw new UsageError('Width must be a valid integer.');
   }
   if (!Number.isInteger(maxDepth)) {
-    throw new Error('Max depth must be a valid integer.');
+    throw new UsageError('Max depth must be a valid integer.');
   }
   if (!['registry', 'disk'].includes(loadDataFrom)) {
-    throw new Error('`loadDataFrom` must be one of `registry`, `disk`.');
+    throw new UsageError('`loadDataFrom` must be one of `registry`, `disk`.');
   }
   if (typeof onProgress !== 'function') {
-    throw new Error('`onProgress` must be a function.');
+    throw new UsageError('`onProgress` must be a function.');
   }
   if (licensePolicy) {
     if (typeof licensePolicy !== 'object') {
-      throw new Error('License policy must be a valid object.');
+      throw new UsageError('License policy must be a valid object.');
     }
     Object.entries(licensePolicy).forEach(([severity, data]) => {
       if (!SUPPORTED_SEVERITIES.includes(severity)) {
-        throw new Error(`License policy keys must be one of ${SUPPORTED_SEVERITIES.map(s => `\`${s}\``).join(', ')}.`);
+        throw new UsageError(
+          `License policy keys must be one of ${SUPPORTED_SEVERITIES.map((s) => `\`${s}\``).join(
+            ', ',
+          )}.`,
+        );
       }
       if (!Array.isArray(data)) {
-        throw new Error(`License policy values must be arrays of strings.`);
+        throw new UsageError(`License policy values must be arrays of strings.`);
       }
     });
   }


### PR DESCRIPTION
When encountering an unexpected error, Sandworm now asks users to submit a crash report.

<img width="957" alt="image" src="https://user-images.githubusercontent.com/5381731/225652863-d991231c-e403-4ac7-841f-8c01fdbfb140.png">

This happens only in interactive envs (`process.stdin.isTTY`).

ℹ️  A new `Error` subclass has been added: `UsageError`. Usage errors are "expected", related to setup/usage, and do not trigger the crash report process.

Testing it out:
- add a throw somewhere in the code
- try each option in the select
- reports should be visible in our `sandworm-audit` project, in the `production` env
- try running it in a dir without a manifest file, to verify that usage errors don't trigger the prompt

Closes #75 