### PR TITLE
Make audit output configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Options:
       --fo, --fail-on         Fail policy JSON string   [string] [default: "[]"]
   -s, --summary               Print a summary of the audit results to the
                               console                  [boolean] [default: true]
+      --skip-tree             Don't output the dependency tree chart
+                                                      [boolean] [default: false]
+      --skip-treemap          Don't output the dependency treemap chart
+                                                      [boolean] [default: false]
+      --skip-csv              Don't output the dependency csv file
+                                                      [boolean] [default: false]
+      --skip-report           Don't output the report json file
+                                                      [boolean] [default: false]
+      --skip-all              Don't output any file   [boolean] [default: false]
 ```
 
 ### Documentation

--- a/src/charts/tree.js
+++ b/src/charts/tree.js
@@ -45,6 +45,8 @@ const buildTree = (
     logger.log(
       '- Reduce the depth of the tree represented by passing the `--max-depth` option to Sandworm',
     );
+    logger.log('- Use the `--skip-tree` option to skip building the tree');
+    logger.log('- Try another package manager');
   }
 
   // Construct an ordinal color scale

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -5,12 +5,13 @@ const SUPPORTED_SEVERITIES = ['critical', 'high', 'moderate', 'low'];
 module.exports = ({
   appPath,
   dependencyGraph,
-  minDisplayedSeverity,
-  width,
-  maxDepth,
-  loadDataFrom,
   licensePolicy,
+  loadDataFrom,
+  maxDepth,
+  minDisplayedSeverity,
   onProgress,
+  output,
+  width,
 }) => {
   if (!appPath) {
     throw new UsageError(
@@ -58,6 +59,16 @@ module.exports = ({
       }
       if (!Array.isArray(data)) {
         throw new UsageError(`License policy values must be arrays of strings.`);
+      }
+    });
+  }
+
+  if (!Array.isArray(output)) {
+    throw new UsageError('`output` must be an array.');
+  } else {
+    output.forEach((type) => {
+      if (!['tree', 'treemap', 'csv'].includes(type)) {
+        throw new UsageError('`output` elements must be one of "tree", "treemap", or "csv".');
       }
     });
   }


### PR DESCRIPTION
This PR adds the following command-line options:

```
      --skip-tree             Don't output the dependency tree chart
                                                      [boolean] [default: false]
      --skip-treemap          Don't output the dependency treemap chart
                                                      [boolean] [default: false]
      --skip-csv              Don't output the dependency csv file
                                                      [boolean] [default: false]
      --skip-json             Don't output the report json file
                                                      [boolean] [default: false]
      --skip-output           Don't output any file   [boolean] [default: false]
```

ℹ️ All `yargs` options retrieved via `argv` have been updated to use the long, camelcase getter for readability

Closes #49 