### PR TITLE
Show tips while building dep graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Options:
       --skip-report           Don't output the report json file
                                                       [boolean] [default: false]
       --skip-all              Don't output any file   [boolean] [default: false]
+      --show-tips             Show Sandworm tips while building the dependency
+                              graph                    [boolean] [default: true]
 ```
 
 ### Documentation

--- a/src/cli/cmds/audit.js
+++ b/src/cli/cmds/audit.js
@@ -119,6 +119,12 @@ exports.builder = (yargs) =>
       default: false,
       describe: "Don't output any file",
       type: 'boolean',
+    })
+    .option('show-tips', {
+      demandOption: false,
+      default: true,
+      describe: 'Show Sandworm tips while building the dependency graph',
+      type: 'boolean',
     });
 
 exports.handler = async (argv) => {
@@ -157,9 +163,14 @@ exports.handler = async (argv) => {
       errors,
     } = await getReport({
       appPath,
-      includeDev: fileConfig.includeDev || argv.includeDev,
-      showVersions: fileConfig.showVersions || argv.showVersions,
-      rootIsShell: fileConfig.rootIsShell || argv.rootIsShell,
+      includeDev:
+        typeof fileConfig.includeDev !== 'undefined' ? fileConfig.includeDev : argv.includeDev,
+      showVersions:
+        typeof fileConfig.showVersions !== 'undefined'
+          ? fileConfig.showVersions
+          : argv.showVersions,
+      rootIsShell:
+        typeof fileConfig.rootIsShell !== 'undefined' ? fileConfig.rootIsShell : argv.rootIsShell,
       maxDepth: fileConfig.maxDepth || argv.maxDepth,
       licensePolicy:
         fileConfig.licensePolicy || (argv.licensePolicy && JSON.parse(argv.licensePolicy)),
@@ -176,7 +187,10 @@ exports.handler = async (argv) => {
             !(typeof fileConfig.skipCsv !== 'undefined' ? !!fileConfig.skipCsv : argv.skipCsv) &&
               'csv',
           ].filter((o) => o),
-      onProgress: onProgress(ora),
+      onProgress: onProgress({
+        ora,
+        showTips: typeof fileConfig.showTips !== 'undefined' ? fileConfig.showTips : argv.showTips,
+      }),
     });
 
     // ********************
@@ -305,6 +319,8 @@ exports.handler = async (argv) => {
         'New version available! Run "npm i -g @sandworm/audit" to update.',
       );
     }
+
+    process.exit();
   } catch (error) {
     await handleCrash(error, appPath);
   }

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -4,10 +4,12 @@ const colors = {
   BLACK: '\x1b[30m',
   CYAN: '\x1b[36m',
   BG_CYAN: '\x1b[46m',
+  BG_GRAY: '\x1b[100m',
   RED: '\x1b[31m',
   DIM: '\x1b[2m',
   CRIMSON: '\x1b[38m',
   GREEN: '\x1b[32m',
+  UNDERLINE: '\x1b[4m',
 };
 const SEVERITY_ICONS = {
   critical: '🔴',

--- a/src/cli/tips.js
+++ b/src/cli/tips.js
@@ -1,0 +1,48 @@
+const logger = require('./logger');
+
+const tips = [
+  {
+    message: 'Configure Sandworm with a config file',
+    example: '.sandworm.config.json',
+    url: 'https://docs.sandworm.dev/audit/configuration',
+  },
+  {
+    message: 'Tell Sandworm which licenses are disallowed',
+    example: 'sandworm-audit --license-policy \'{"critical": ["cat:Network Protective"]}\'',
+    url: 'https://docs.sandworm.dev/audit/license-policies',
+  },
+  {
+    message: 'Run Sandworm in your CI to enforce security rules',
+    example: 'sandworm audit --skip-all --fail-on=\'["*.critical", "*.high"]\'',
+    url: 'https://docs.sandworm.dev/audit/fail-policies',
+  },
+  {
+    message: 'Mark issues as resolved with Sandworm',
+    example: 'sandworm resolve ISSUE-ID',
+    url: 'https://docs.sandworm.dev/audit/resolving-issues',
+  },
+  {
+    message: 'Save issue resolution info to your repo',
+    example: 'resolved-issues.json',
+    url: 'https://docs.sandworm.dev/audit/resolving-issues',
+  },
+];
+
+const tip = () => {
+  const currentTipIndex = Math.floor(Math.random() * tips.length);
+  const {message, example, url} = tips[currentTipIndex];
+
+  const currentTip = `${logger.colors.DIM}\n//\n// ${logger.colors.RESET}💡 ${
+    logger.colors.DIM
+  }${message}${
+    example
+      ? `\n//    ${logger.colors.RESET}${logger.colors.BG_GRAY}${example}${logger.colors.RESET}${logger.colors.DIM}`
+      : ''
+  }${url ? `\n//    ${logger.colors.UNDERLINE}${url}${logger.colors.RESET}` : ''}\n${
+    logger.colors.DIM
+  }//${logger.colors.RESET}`;
+
+  return currentTip;
+};
+
+module.exports = tip;


### PR DESCRIPTION
This PR adds displaying Sandworm usage tips while the dependency graph is loading.
Tips can be turned off by setting the `--show-tips=false` command line option, or by using the `showTips` key in the config file.
Tips consist of a message, an example, and an URL. They are rotated every 10s.

![2023-03-24 23 25 09](https://user-images.githubusercontent.com/5381731/227646120-757d698b-b165-4d43-9238-bdd75eadbbc0.gif)

Closes #86 