### PR TITLE
Accept wildcard version in resolved issue id

### DIFF
--- a/src/graph/generatePnpmGraph.js
+++ b/src/graph/generatePnpmGraph.js
@@ -1,4 +1,9 @@
-const {processDependenciesForPackage, processPlaceholders, makeNode} = require('./utils');
+const {
+  processDependenciesForPackage,
+  processPlaceholders,
+  makeNode,
+  SEMVER_REGEXP,
+} = require('./utils');
 
 const parsePath = (path) => {
   // parse pnpm lockfile package names like:
@@ -10,12 +15,9 @@ const parsePath = (path) => {
   // /@nestjs/schematics/9.1.0(typescript@5.0.3)
   // /ts-node/10.9.1(@types/node@14.18.36)(typescript@4.9.3)
   // see https://github.com/pnpm/pnpm/pull/5810
-  const results = path.match(
-    // basically /^\/(.*?)\/(SEMVER)(.*?)$/
-    /^\/(.*?)\/((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?)(.*?)$/,
-  );
-  const name = results[1];
-  const version = results[2];
+  const results = path.match(new RegExp(`^/(.*?)/(${SEMVER_REGEXP.source})(.*?)$`));
+  const name = results?.[1];
+  const version = results?.[2];
 
   return {name, version};
 };

--- a/src/graph/utils.js
+++ b/src/graph/utils.js
@@ -1,6 +1,9 @@
 const https = require('https');
 const semverLib = require('semver');
 
+const SEMVER_REGEXP =
+  /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?/;
+
 const parseDependencyString = (depstring) => {
   const parts = depstring.split('@');
   let semver = parts.pop();
@@ -374,6 +377,7 @@ const getRegistryDataMultiple = async (packages, onProgress = () => {}) => {
 };
 
 module.exports = {
+  SEMVER_REGEXP,
   makeNode,
   parseDependencyString,
   processDependenciesForPackage,


### PR DESCRIPTION
Since Sandworm IDs have the affected package version in them, it's possible that resolved issues get reactivated when updating. This allows users to specify a wildcard (*) for the version in the issue id.

- `sandworm resolve ID` can now match and aggregate paths from multiple issues for a single ID
- a semver regexp is now generally available

Closes #94 